### PR TITLE
Remove dependency on ordereddict if sys.version_info > (2,7)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ requires = readfile("requirements.txt")
 version = readfile("VERSION")[0].strip()
 
 if sys.version_info >= (2, 7):
-    requires.remove(u'ordereddict>=1.1')
+    requires.remove('ordereddict>=1.1')
 
 setup(
     name='sphinxcontrib-bibtex',


### PR DESCRIPTION
If installing with a Python 2.7+ interpreter, the dependency on ordereddict is not necessary since collections.OrderedDict is a built-in. This pull request checks the version of Python in setup.py, and if it's >= 2.7, it will remove the dependency on ordereddict so that it is not unnecessarily installed.
