### PR TITLE
Allow to add all citations of a given type

### DIFF
--- a/sphinxcontrib/bibtex/cache.py
+++ b/sphinxcontrib/bibtex/cache.py
@@ -201,10 +201,12 @@ class BibliographyCache:
                  encoding=None,
                  curly_bracket_strip=True,
                  labelprefix="",
+                 filter=None
                  ):
         self.docname = docname
         self.bibfiles = bibfiles if bibfiles is not None else []
         self.cite = cite
+        self.filter = filter
         self.style = style
         self.list_ = list_
         self.enumtype = enumtype

--- a/sphinxcontrib/bibtex/directives.py
+++ b/sphinxcontrib/bibtex/directives.py
@@ -61,7 +61,7 @@ class BibliographyDirective(Directive):
         'cited': directives.flag,
         'notcited': directives.flag,
         'all': directives.flag,
-        'type': directives.unchanged,
+        'filter': directives.unchanged,
         'style': directives.unchanged,
         'list': directives.unchanged,
         'enumtype': directives.unchanged,
@@ -89,17 +89,12 @@ class BibliographyDirective(Directive):
             env.docname, env.new_serialno('bibtex'))
         info = BibliographyCache(
             docname=env.docname,
-            cite=(
-                "all"
-                if "all" in self.options else (
-                    "type:" + self.options["type"] if "type" in self.options else(
-                        "notcited"
-                        if "notcited" in self.options else (
-                            "cited")))),
+            cite=("all" if "all" in self.options else ("notcited" if "notcited" in self.options else "cited")),
             list_=self.options.get("list", "citation"),
             enumtype=self.options.get("enumtype", "arabic"),
             start=self.options.get("start", 1),
             style=self.options.get("style", "plain"),
+            filter=self.options.get("filter", None),
             encoding=self.options.get(
                 'encoding',
                 'latex+' + self.state.document.settings.input_encoding),


### PR DESCRIPTION
This (small) patch allows to add all papers of a given type.

By example:

.. bibliography:: publications.bib
   :list: bullet
   :type: journal incollection article

Then all citations of type journal, incollection or article will be
added.
