### PR TITLE
Resolve Reference Links Correctly

### DIFF
--- a/sphinxcontrib/bibtex/__init__.py
+++ b/sphinxcontrib/bibtex/__init__.py
@@ -86,6 +86,8 @@ def process_citation_references(app, doctree, docname):
                 app.warn("could not relabel citation reference [%s]" % key)
             else:
                 node[0] = docutils.nodes.Text('[' + label + ']')
+                uriparts = node['refuri'].split("#")
+                node['refuri'] = uriparts[0] + "#" + label
 
 
 def check_duplicate_labels(app, env):


### PR DESCRIPTION
While reprocessing the nodes to change the labels, the refuris should also be
updated, because in the expanded latex the refuris will be used to reference a
cite to its corresponding bibitem and not the labels.

Btw. I don't think it's the optimal solution. It should just be proof of concept.
I am happy to improve the pull request and update unit tests and documentation with some guidance.

With this I think #44 can be closed, which I will do. Please respond here instead of in that issue. Thanks.
