### PR TITLE
add ordereddict to the requirements conditionally

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ pybtex-docutils>=0.2.0
 six>=1.4.1
 Sphinx>=1.0
 oset>=0.1.3
-
+ordereddict>=1.1; python_version < '2.7'


### PR DESCRIPTION
The ordereddict package is required for Python versions below 2.7, thus for example for 2.6 (supported by Sphinx). The code imports it correctly but it had to be manually installed. Make it automatic using conditional listing in requirements.txt, working for pip>=6.0.