### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,14 +32,14 @@ The extension is inspired by Matthew Brett's
     :target: https://coveralls.io/github/mcmtroffaes/sphinxcontrib-bibtex?branch=develop
     :alt: coveralls.io
 
-.. |downloads| image:: https://pypip.in/d/sphinxcontrib-bibtex/badge.png
+.. |downloads| image:: https://img.shields.io/pypi/dm/sphinxcontrib-bibtex.svg
     :target: https://pypi.python.org/pypi/sphinxcontrib-bibtex/
     :alt: downloads
 
-.. |version| image:: https://pypip.in/v/sphinxcontrib-bibtex/badge.png
+.. |version| image:: https://img.shields.io/pypi/v/sphinxcontrib-bibtex.svg
     :target: https://pypi.python.org/pypi/sphinxcontrib-bibtex/
     :alt: latest version
 
-.. |license| image:: https://pypip.in/license/sphinxcontrib-bibtex/badge.png
+.. |license| image:: https://img.shields.io/pypi/l/sphinxcontrib-bibtex.svg
     :target: https://pypi.python.org/pypi/sphinxcontrib-bibtex/
     :alt: license


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20sphinxcontrib-bibtex))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `sphinxcontrib-bibtex`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.