### PR TITLE
Fix tests failures with Sphinx 1.7 by always registering the transform

### DIFF
--- a/sphinxcontrib/bibtex/__init__.py
+++ b/sphinxcontrib/bibtex/__init__.py
@@ -138,9 +138,15 @@ def setup(app):
         app.add_directive("bibliography", BibliographyDirective)
         app.add_role("cite", CiteRole())
         app.add_node(bibliography)
-        app.add_transform(BibliographyTransform)
     else:
         assert _directives["bibliography"] is BibliographyDirective
+    try:
+        transforms = app.registry.get_transforms()
+    except AttributeError:  # Sphinx < 1.7
+        from sphinx.io import SphinxStandaloneReader
+        transforms = SphinxStandaloneReader.transforms
+    if BibliographyTransform not in transforms:
+        app.add_transform(BibliographyTransform)
 
     # Parallel read is not safe at the moment: in the current design,
     # the document that contains references must be read last for all


### PR DESCRIPTION
In sphinx-doc/sphinx@27ea988f6e5a6637, the transforms handling has been moved into a registry, so the list of transforms no longer persists between tests runs.