### PR TITLE
Adapt test_latex_refs to changes in Sphinx 1.8

### DIFF
--- a/test/test_latex_refs.py
+++ b/test/test_latex_refs.py
@@ -7,6 +7,7 @@
 """
 
 import re
+import sphinx
 from sphinx_testing.util import path, with_app
 
 srcdir = path(__file__).dirname().joinpath('latex_refs').abspath()
@@ -20,7 +21,11 @@ def teardown_module():
 def test_latex_refs(app, status, warning):
     app.builder.build_all()
     output = (app.outdir / "test.tex").read_text(encoding='utf-8')
-    assert re.search(
-        '\\\\hyperref\[(\\\\detokenize{)?contents:huygens(})?\]', output)
-    assert re.search(
-        '\\\\label{(\\\\detokenize{)?contents:huygens(})?}}', output)
+    if sphinx.version_info >= (1, 8):
+        assert r'\sphinxcite{contents:huygens}' in output
+        assert r'\bibitem[Huy57]{contents:huygens}' in output
+    else:
+        assert re.search(
+            r'\\hyperref\[(\\detokenize{)?contents:huygens(})?\]', output)
+        assert re.search(
+            r'\\label{(\\detokenize{)?contents:huygens(})?}}', output)


### PR DESCRIPTION
In sphinx-doc/sphinx@92d8935df07abf78, \hyperref was changed to `\cite`, and later in sphinx-doc/sphinx@8bc136a9cb415f87 it was changed to `\sphinxcite`.

Partially fixes #149 (the remaining failure is a tinkerer bug).