### PR TITLE
Add override=True when registering bibliography node

### DIFF
--- a/sphinxcontrib/bibtex/__init__.py
+++ b/sphinxcontrib/bibtex/__init__.py
@@ -142,7 +142,7 @@ def setup(app):
     if "bibliography" not in _directives:
         app.add_directive("bibliography", BibliographyDirective)
         app.add_role("cite", CiteRole())
-        app.add_node(bibliography)
+        app.add_node(bibliography, override=True)
     else:
         assert _directives["bibliography"] is BibliographyDirective
     try:


### PR DESCRIPTION
sphinx-testing 0.8 restores docutils directives and roles (but not nodes) after each test exits, so the `"bibliography" not in _directives` check will be satisfied on subsequent test runs.

However, registering a node twice raises a warning, which is converted to error in our tests as they use `warningiserror=True`. Adding `override=True` fixes it.

Fixes #157.