### PR TITLE
only process citations and citation_references with a 'bibtex' class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+.noseids

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 .noseids
+nosetests.xml

--- a/sphinxcontrib/bibtex/__init__.py
+++ b/sphinxcontrib/bibtex/__init__.py
@@ -18,7 +18,7 @@ from sphinxcontrib.bibtex.cache import Cache
 from sphinxcontrib.bibtex.nodes import bibliography
 from sphinxcontrib.bibtex.roles import CiteRole
 from sphinxcontrib.bibtex.directives import BibliographyDirective
-from sphinxcontrib.bibtex.transforms import BibliographyTransform
+from sphinxcontrib.bibtex.transforms import BibliographyTransform, OverrideCitationReferences
 import six
 
 
@@ -57,6 +57,8 @@ def process_citations(app, doctree, docname):
     :type docname: :class:`str`
     """
     for node in doctree.traverse(docutils.nodes.citation):
+        if "bibtex" not in node.attributes.get('classes', []):
+            continue
         key = node[0].astext()
         try:
             label = app.env.bibtex_cache.get_label_from_key(key)
@@ -79,20 +81,17 @@ def process_citation_references(app, doctree, docname):
     # sphinx has already turned citation_reference nodes
     # into reference nodes, so iterate over reference nodes
     for node in doctree.traverse(docutils.nodes.reference):
-        # exclude sphinx [source] labels
-        if isinstance(node[0], docutils.nodes.Element):
-            if 'viewcode-link' in node[0]['classes']:
-                continue
+        if "bibtex" not in node.attributes.get('classes', []):
+            continue
         text = node[0].astext()
-        if text.startswith('[') and text.endswith(']'):
-            key = text[1:-1]
-            try:
-                label = app.env.bibtex_cache.get_label_from_key(key)
-            except KeyError:
-                logger.warning(
-                    "could not relabel citation reference [%s]" % key)
-            else:
-                node[0] = docutils.nodes.Text('[' + label + ']')
+        key = text[1:-1]
+        try:
+            label = app.env.bibtex_cache.get_label_from_key(key)
+        except KeyError:
+            logger.warning(
+                "could not relabel citation reference [%s]" % key)
+        else:
+            node[0] = docutils.nodes.Text('[' + label + ']')
 
 
 def check_duplicate_labels(app, env):
@@ -152,6 +151,8 @@ def setup(app):
         transforms = SphinxStandaloneReader.transforms
     if BibliographyTransform not in transforms:
         app.add_transform(BibliographyTransform)
+    if OverrideCitationReferences not in transforms:
+        app.add_transform(OverrideCitationReferences)
 
     # Parallel read is not safe at the moment: in the current design,
     # the document that contains references must be read last for all

--- a/sphinxcontrib/bibtex/__init__.py
+++ b/sphinxcontrib/bibtex/__init__.py
@@ -18,7 +18,10 @@ from sphinxcontrib.bibtex.cache import Cache
 from sphinxcontrib.bibtex.nodes import bibliography
 from sphinxcontrib.bibtex.roles import CiteRole
 from sphinxcontrib.bibtex.directives import BibliographyDirective
-from sphinxcontrib.bibtex.transforms import BibliographyTransform, OverrideCitationReferences
+from sphinxcontrib.bibtex.transforms import (
+    BibliographyTransform,
+    OverrideCitationReferences,
+    HandleMissingCitesTransform)
 import six
 
 
@@ -153,6 +156,8 @@ def setup(app):
         app.add_transform(BibliographyTransform)
     if OverrideCitationReferences not in transforms:
         app.add_transform(OverrideCitationReferences)
+    if HandleMissingCitesTransform not in transforms:
+        app.add_transform(HandleMissingCitesTransform)
 
     # Parallel read is not safe at the moment: in the current design,
     # the document that contains references must be read last for all

--- a/sphinxcontrib/bibtex/__init__.py
+++ b/sphinxcontrib/bibtex/__init__.py
@@ -13,6 +13,7 @@
 
 import docutils.nodes
 import docutils.parsers.rst
+import sphinx
 import sphinx.util
 from sphinxcontrib.bibtex.cache import Cache
 from sphinxcontrib.bibtex.nodes import bibliography
@@ -154,10 +155,11 @@ def setup(app):
         transforms = SphinxStandaloneReader.transforms
     if BibliographyTransform not in transforms:
         app.add_transform(BibliographyTransform)
-    if OverrideCitationReferences not in transforms:
-        app.add_transform(OverrideCitationReferences)
-    if HandleMissingCitesTransform not in transforms:
-        app.add_post_transform(HandleMissingCitesTransform)
+    if sphinx.version_info < (2,):
+        if OverrideCitationReferences not in transforms:
+            app.add_transform(OverrideCitationReferences)
+        if HandleMissingCitesTransform not in transforms:
+            app.add_post_transform(HandleMissingCitesTransform)
 
     # Parallel read is not safe at the moment: in the current design,
     # the document that contains references must be read last for all

--- a/sphinxcontrib/bibtex/__init__.py
+++ b/sphinxcontrib/bibtex/__init__.py
@@ -157,7 +157,7 @@ def setup(app):
     if OverrideCitationReferences not in transforms:
         app.add_transform(OverrideCitationReferences)
     if HandleMissingCitesTransform not in transforms:
-        app.add_transform(HandleMissingCitesTransform)
+        app.add_post_transform(HandleMissingCitesTransform)
 
     # Parallel read is not safe at the moment: in the current design,
     # the document that contains references must be read last for all

--- a/sphinxcontrib/bibtex/roles.py
+++ b/sphinxcontrib/bibtex/roles.py
@@ -32,6 +32,8 @@ class CiteRole(XRefRole):
         refnodes = [
             self.backend.citation_reference(_fake_entry(key), document)
             for key in keys]
+        for refnode in refnodes:
+            refnode.set_class('bibtex')
         for key in keys:
             env.bibtex_cache.add_cited(key, env.docname)
         return refnodes, []

--- a/sphinxcontrib/bibtex/roles.py
+++ b/sphinxcontrib/bibtex/roles.py
@@ -33,7 +33,7 @@ class CiteRole(XRefRole):
             self.backend.citation_reference(_fake_entry(key), document)
             for key in keys]
         for refnode in refnodes:
-            refnode.set_class('bibtex')
+            refnode['classes'].append('bibtex')
         for key in keys:
             env.bibtex_cache.add_cited(key, env.docname)
         return refnodes, []

--- a/sphinxcontrib/bibtex/transforms.py
+++ b/sphinxcontrib/bibtex/transforms.py
@@ -16,6 +16,7 @@
 import docutils.nodes
 import docutils.transforms
 import sphinx.util
+from sphinx import addnodes
 
 from pybtex.plugin import find_plugin
 
@@ -50,6 +51,41 @@ def transform_url_command(textnode):
         return node
     else:
         return textnode
+
+
+class OverrideCitationReferences(docutils.transforms.Transform):
+    """
+    Replace citation references by pending_xref nodes before the default
+    docutils transform tries to resolve them.
+
+    This transform overrides sphinx.transforms.CitationReferences,
+    in order to propogate the classes of the citation_reference node
+    to the pending_xref node (see PR sphinx-doc/sphinx#6147)
+    """
+    # the default priority of sphinx.transforms.CitationReferences is 619
+    default_priority = 618
+
+    def apply(self, **kwargs):
+        # type: (Any) -> None
+        # mark citation labels as not smartquoted
+        # for citation in self.document.traverse(nodes.citation):
+        #     label = cast(nodes.label, citation[0])
+        #     label['support_smartquotes'] = False
+
+        for citation_ref in self.document.traverse(
+                docutils.nodes.citation_reference):
+            cittext = citation_ref.astext()
+            refnode = addnodes.pending_xref(
+                cittext, refdomain='std', reftype='citation',
+                reftarget=cittext, refwarn=True,
+                support_smartquotes=False,
+                ids=citation_ref["ids"])
+            refnode.source = citation_ref.source or citation_ref.parent.source
+            refnode.line = citation_ref.line or citation_ref.parent.line
+            refnode += docutils.nodes.Text('[' + cittext + ']')
+            for class_name in citation_ref.attributes.get('classes', []):
+                refnode.set_class(class_name)
+            citation_ref.parent.replace(citation_ref, refnode)
 
 
 class BibliographyTransform(docutils.transforms.Transform):
@@ -102,6 +138,7 @@ class BibliographyTransform(docutils.transforms.Transform):
                     citation += backend.paragraph(entry)
                 else:  # "citation"
                     citation = backend.citation(entry, self.document)
+                    citation.set_class('bibtex')
                     # backend.citation(...) uses entry.key as citation label
                     # we change it to entry.label later onwards
                     # but we must note the entry.label now;

--- a/sphinxcontrib/bibtex/transforms.py
+++ b/sphinxcontrib/bibtex/transforms.py
@@ -90,9 +90,9 @@ class OverrideCitationReferences(docutils.transforms.Transform):
 
 class HandleMissingCitesTransform(docutils.transforms.Transform):
     """ before sphinx.transforms.post_transforms.ReferencesResolver
-    missing citations need to be handled
+    missing citations need to be handled (default_priority=10)
     """
-    default_priority = 620
+    default_priority = 9
 
     def apply(self):
         # type: () -> None

--- a/sphinxcontrib/bibtex/transforms.py
+++ b/sphinxcontrib/bibtex/transforms.py
@@ -66,7 +66,7 @@ class OverrideCitationReferences(docutils.transforms.Transform):
     default_priority = 618
 
     def apply(self, **kwargs):
-        # type: (Any) -> None
+
         # mark citation labels as not smartquoted
         # for citation in self.document.traverse(nodes.citation):
         #     label = cast(nodes.label, citation[0])

--- a/sphinxcontrib/bibtex/transforms.py
+++ b/sphinxcontrib/bibtex/transforms.py
@@ -84,7 +84,7 @@ class OverrideCitationReferences(docutils.transforms.Transform):
             refnode.line = citation_ref.line or citation_ref.parent.line
             refnode += docutils.nodes.Text('[' + cittext + ']')
             for class_name in citation_ref.attributes.get('classes', []):
-                refnode.set_class(class_name)
+                refnode['classes'].append(class_name)
             citation_ref.parent.replace(citation_ref, refnode)
 
 
@@ -161,7 +161,7 @@ class BibliographyTransform(docutils.transforms.Transform):
                     citation += backend.paragraph(entry)
                 else:  # "citation"
                     citation = backend.citation(entry, self.document)
-                    citation.set_class('bibtex')
+                    citation['classes'].append('bibtex')
                     # backend.citation(...) uses entry.key as citation label
                     # we change it to entry.label later onwards
                     # but we must note the entry.label now;

--- a/test/test_issue61.py
+++ b/test/test_issue61.py
@@ -20,5 +20,5 @@ def teardown_module():
 def test_multiple_keys(app, status, warning):
     app.builder.build_all()
     output = (app.outdir / "contents.html").read_text(encoding='utf-8')
-    assert re.search('class="reference internal" href="#testone"', output)
-    assert re.search('class="reference internal" href="#testtwo"', output)
+    assert re.search('class="bibtex reference internal" href="#testone"', output)
+    assert re.search('class="bibtex reference internal" href="#testtwo"', output)

--- a/test/test_issue61.py
+++ b/test/test_issue61.py
@@ -20,5 +20,7 @@ def teardown_module():
 def test_multiple_keys(app, status, warning):
     app.builder.build_all()
     output = (app.outdir / "contents.html").read_text(encoding='utf-8')
-    assert re.search('class="bibtex reference internal" href="#testone"', output)
-    assert re.search('class="bibtex reference internal" href="#testtwo"', output)
+    assert re.search(
+        'class="bibtex reference internal" href="#testone"', output)
+    assert re.search(
+        'class="bibtex reference internal" href="#testtwo"', output)

--- a/test/test_issue62.py
+++ b/test/test_issue62.py
@@ -18,12 +18,12 @@ def teardown_module():
 
 def extract_references(code):
     return frozenset(re.findall(
-        '<a class="reference internal" href="([^"]+)"', code))
+        '<a class="bibtex reference internal" href="([^"]+)"', code))
 
 
 def extract_citations(code):
     return frozenset(re.findall(
-        '<table class="docutils citation" frame="void" id="([^"]+)"', code))
+        '<table class="bibtex docutils citation" frame="void" id="([^"]+)"', code))
 
 
 def check_code(code, refs, cites, otherrefs, othercites):

--- a/test/test_issue62.py
+++ b/test/test_issue62.py
@@ -23,7 +23,8 @@ def extract_references(code):
 
 def extract_citations(code):
     return frozenset(re.findall(
-        '<table class="bibtex docutils citation" frame="void" id="([^"]+)"', code))
+        '<table class="bibtex docutils citation" frame="void" id="([^"]+)"',
+        code))
 
 
 def check_code(code, refs, cites, otherrefs, othercites):

--- a/test/test_issue87.py
+++ b/test/test_issue87.py
@@ -21,15 +21,15 @@ def test_issue87(app, status, warning):
     app.builder.build_all()
     output = (app.outdir / "doc0.html").read_text(encoding='utf-8')
     assert re.search(
-        'class="reference internal" href="#tag0-2009-mandel"', output)
+        'class="bibtex reference internal" href="#tag0-2009-mandel"', output)
     assert re.search(
-        'class="reference internal" href="#tag0-2003-evensen"', output)
+        'class="bibtex reference internal" href="#tag0-2003-evensen"', output)
     assert re.search('AMan09', output)
     assert re.search('AEve03', output)
     output = (app.outdir / "doc1.html").read_text(encoding='utf-8')
     assert re.search(
-        'class="reference internal" href="#tag1-2009-mandel"', output)
+        'class="bibtex reference internal" href="#tag1-2009-mandel"', output)
     assert not re.search(
-        'class="reference internal" href="#tag1-2003-evensen"', output)
+        'class="bibtex reference internal" href="#tag1-2003-evensen"', output)
     assert re.search('BMan09', output)
     assert not re.search('BEve03', output)

--- a/test/test_sphinx.py
+++ b/test/test_sphinx.py
@@ -21,15 +21,15 @@ def teardown_module():
 def test_sphinx(app, status, warning):
     app.builder.build_all()
     warnings = warning.getvalue()
-    assert re.search(u'could not relabel citation \\[Test01\\]', warnings)
-    assert re.search(u'could not relabel citation \\[Test02\\]', warnings)
-    assert re.search(u'could not relabel citation \\[Wa04\\]', warnings)
-    assert re.search(
+    assert not re.search(u'could not relabel citation \\[Test01\\]', warnings)
+    assert not re.search(u'could not relabel citation \\[Test02\\]', warnings)
+    assert not re.search(u'could not relabel citation \\[Wa04\\]', warnings)
+    assert not re.search(
         u'could not relabel citation reference \\[Test01\\]',
         warnings)
-    assert re.search(
+    assert not re.search(
         u'could not relabel citation reference \\[Test02\\]',
         warnings)
-    assert re.search(
+    assert not re.search(
         u'could not relabel citation reference \\[Wa04\\]',
         warnings)


### PR DESCRIPTION
Hey Matthias,

I see you have already considered this in mcmtroffaes/sphinxcontrib-bibtex#155,
well I have the answer :) You need to override `sphinx.transforms.CitationReferences`,
in order to propagate the `cite_reference` classes to `pending_xref`. I have just made a PR
to sphinx (sphinx-doc/sphinx#6147), to fix this upstream. But, for now, you'll see I've added
a modified copy of the transform, with a higher default priority.

FYI The reason that I come across this issue, is that I have been using your excellent package in my own
([see here](https://ipypublish.readthedocs.io/en/latest/markdown_cells.html#references))