### PR TITLE
add :list: citation_key to use bibtex key as citation reference

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -79,8 +79,8 @@ Roles and Directives
      .. bibliography:: refs.bib
         :encoding: latin
 
-   LaTeX control characters are automatically converted to unicode 
-   characters (for instance, to convert ``\'e`` into ``é``). Be sure 
+   LaTeX control characters are automatically converted to unicode
+   characters (for instance, to convert ``\'e`` into ``é``). Be sure
    to write ``\%`` when you intend to format a percent sign.
 
 .. XXX not documenting disable-curly-bracket-strip for now; might remove it
@@ -96,6 +96,32 @@ Roles and Directives
 
 Advanced Features
 -----------------
+
+Keyed Lists
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 0.4.3
+
+You can change the style of the text shown as the citation link for both
+the link in the text and as shown in the bibliography.  While the default
+citation is built from the authors name and publication year as obtained with
+
+.. code-block:: rest
+
+   .. bibliography:: refs1.bib
+      :list: citation
+      :cited:
+
+
+you can alternatively use the bibtex entry name as the key:
+
+.. code-block:: rest
+
+   .. bibliography:: refs1.bib
+      :list: citation_key
+      :cited:
+
+
 
 Bullet Lists and Enumerated Lists
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -326,7 +352,7 @@ To create a bibliography that includes only citations that were cited
 in the current document, use the following filter:
 
 .. code-block:: rest
-                
+
    .. bibliography:: refs.bib
       :filter: docname in docnames
 
@@ -507,4 +533,3 @@ LaTeX output, you can add the following to your LaTeX preamble:
 
    \usepackage{etoolbox}
    \patchcmd{\thebibliography}{\section*{\refname}}{}{}{}
-

--- a/sphinxcontrib/bibtex/directives.py
+++ b/sphinxcontrib/bibtex/directives.py
@@ -127,7 +127,8 @@ class BibliographyDirective(Directive):
             labels={},
             bibfiles=[],
         )
-        if (bibcache.list_ not in set(["bullet", "enumerated", "citation"])):
+        if (bibcache.list_ not in set(["bullet", "enumerated",
+                                       "citation", "citation_key"])):
             logger.warning(
                 "unknown bibliography list type '{0}'.".format(bibcache.list_))
         for bibfile in self.arguments[0].split():

--- a/sphinxcontrib/bibtex/transforms.py
+++ b/sphinxcontrib/bibtex/transforms.py
@@ -100,6 +100,10 @@ class BibliographyTransform(docutils.transforms.Transform):
                 if bibcache.list_ in ["enumerated", "bullet"]:
                     citation = docutils.nodes.list_item()
                     citation += backend.paragraph(entry)
+                elif bibcache.list_ == 'citation_key':
+                    citation = backend.citation(entry, self.document)
+                    key = citation[0].astext()
+                    bibcache.labels[key] = key
                 else:  # "citation"
                     citation = backend.citation(entry, self.document)
                     # backend.citation(...) uses entry.key as citation label


### PR DESCRIPTION
This adds the option to use

```
   .. bibliography:: refs1.bib
      :list: citation_key
      :cited:
```

to use the actual name of the bibtex entry as the displayed citation instead of a word constructed from the author names and year.
