### PR TITLE
Add test with near-identical bibtex entries.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ branches:
   only:
     - develop
 install:
+  # need development version of pybtex for latest bug fix
+  # can remove next line once pybtex version > 0.22.2 is released
+  - "pip install git+https://bitbucket.org/pybtex-devs/pybtex"
   - "pip install codecov sphinx-testing" # required for tests
   - "pip install ."
   - "if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then pip install check-manifest flake8; fi"

--- a/test/issue_173/conf.py
+++ b/test/issue_173/conf.py
@@ -1,0 +1,2 @@
+extensions = ['sphinxcontrib.bibtex']
+exclude_patterns = ['_build']

--- a/test/issue_173/index.rst
+++ b/test/issue_173/index.rst
@@ -1,0 +1,6 @@
+First edition: :cite:`ABC_R1`.
+
+Second edition: :cite:`ABC_R2`.
+
+.. bibliography:: test.bib
+   :all:

--- a/test/issue_173/test.bib
+++ b/test/issue_173/test.bib
@@ -1,0 +1,12 @@
+@manual{ABC_R1,
+  author       = {xyz},
+  title        = {{ABC}},
+  edition      = 1,
+  year         = {2019}
+}
+@manual{ABC_R2,
+  author       = {xyz},
+  title        = {{ABC}},
+  edition      = 2,
+  year         = {2019}
+}

--- a/test/test_issue_173.py
+++ b/test/test_issue_173.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+"""
+    test_issue_173
+    ~~~~~~~~~~~~~~
+
+    Check referencing works with near identical entries.
+"""
+
+from sphinx_testing.util import path, with_app
+
+srcdir = path(__file__).dirname().joinpath('issue_173').abspath()
+
+
+def teardown_module():
+    (srcdir / '_build').rmtree(True)
+
+
+@with_app(srcdir=srcdir, warningiserror=True)
+def test_issue_173(app, status, warning):
+    app.builder.build_all()
+    output = (path(app.outdir) / "index.html").read_text(encoding='utf-8')
+    assert "[xyz19a]" in output
+    assert "[xyz19b]" in output


### PR DESCRIPTION
This is a test for fixing #173. Awaiting upstream fix to be merged here: https://bitbucket.org/pybtex-devs/pybtex/pull-requests/15/ensure-sort-only-sorts-and-that-it-does/diff