### PR TITLE
Allow Sphinx >= 1.7?

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pybtex>=0.20
 pybtex-docutils>=0.2.0
-Sphinx>=2.0
+Sphinx>=1.7
 oset>=0.1.3
 


### PR DESCRIPTION
The Sphinx requirement has been bumped to >= 2.0 in 2515f5902cca8c357c9a7e0e70fd800ef023ba77.

Is this really necessary?

It looks like Sphinx 1.7 also works fine, see https://github.com/spatialaudio/nbsphinx/pull/323

I'm trying to also test older Sphinx versions in my project, but since I depend on `sphinxcontrib-bibtex`, I'm limited to the versions that are supported here.