### PR TITLE
move functions for processing bibfiles to the cache module

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@
 * Improve citation ordering code (reported by ukos-git, see issue
   #182).
 
+* **BACKWARD INCOMPATIBLE**
+  Functions for processing bib files have been moved to the cache
+  module. They are no longer class methods but standalone functions,
+  so they can be more easily reused.
+
 1.0.0 (20 September 2019)
 -------------------------
 

--- a/sphinxcontrib/bibtex/directives.py
+++ b/sphinxcontrib/bibtex/directives.py
@@ -14,10 +14,7 @@ import os.path  # getmtime()
 import sphinx.util
 
 from docutils.parsers.rst import Directive, directives
-from sphinx.util.console import bold, standout
-
-from pybtex.database.input import bibtex
-from pybtex.database import BibliographyData
+from sphinx.util.console import standout
 
 from sphinxcontrib.bibtex.cache import BibliographyCache, process_bibfile
 from sphinxcontrib.bibtex.nodes import bibliography


### PR DESCRIPTION
So they can be more easily shared with other extensions.