### PR TITLE
Allow custom label brackets

### DIFF
--- a/sphinxcontrib/bibtex/__init__.py
+++ b/sphinxcontrib/bibtex/__init__.py
@@ -151,7 +151,10 @@ def process_citation_references(app, doctree, docname):
             text = node[0].astext()
             key = text[1:-1]
             label = app.env.bibtex_cache.get_label_from_key(key)
-            node[0] = docutils.nodes.Text('[' + label + ']')
+            node[0] = docutils.nodes.Text(
+                app.config.bibtex_cite_bracket_left
+                + label
+                + app.config.bibtex_cite_bracket_right)
 
 
 def check_duplicate_labels(app, env):
@@ -214,6 +217,8 @@ def setup(app):
     app.add_config_value("bibtex_encoding", "utf-8-sig", "html")
     app.add_config_value("bibtex_bibliography_header", "", "html")
     app.add_config_value("bibtex_footbibliography_header", "", "html")
+    app.add_config_value("bibtex_cite_bracket_left", "[", "html")
+    app.add_config_value("bibtex_cite_bracket_right", "]", "html")
     app.connect("builder-inited", init_bibtex_cache)
     app.connect("env-merge-info", merge_bibtex_cache)
     app.connect("env-purge-doc", purge_bibtex_cache)

--- a/test/json/conf.py
+++ b/test/json/conf.py
@@ -1,2 +1,0 @@
-extensions = ['sphinxcontrib.bibtex']
-exclude_patterns = ['_build']

--- a/test/json/index.rst
+++ b/test/json/index.rst
@@ -1,3 +1,0 @@
-:cite:`test01`
-
-.. bibliography:: test.bib

--- a/test/json/test.bib
+++ b/test/json/test.bib
@@ -1,4 +1,0 @@
-@Misc{test01,
-  author =    {A. One},
-  title =     {Een},
-}

--- a/test/roots/test-cite_brackets/bibtex.json
+++ b/test/roots/test-cite_brackets/bibtex.json
@@ -1,0 +1,7 @@
+{
+    "cited": {
+        "index": [
+            "1657:huygens"
+        ]
+    }
+}

--- a/test/roots/test-cite_brackets/conf.py
+++ b/test/roots/test-cite_brackets/conf.py
@@ -1,0 +1,5 @@
+extensions = ['sphinxcontrib.bibtex']
+exclude_patterns = ['_build']
+bibtex_bibfiles = ['test.bib']
+bibtex_cite_bracket_left = '<'
+bibtex_cite_bracket_right = '>'

--- a/test/roots/test-cite_brackets/index.rst
+++ b/test/roots/test-cite_brackets/index.rst
@@ -1,0 +1,3 @@
+:cite:`1657:huygens`
+
+.. bibliography::

--- a/test/roots/test-cite_brackets/test.bib
+++ b/test/roots/test-cite_brackets/test.bib
@@ -1,0 +1,10 @@
+@InCollection{1657:huygens,
+  author = 	 {Christiaan Huygens},
+  title = 	 {De Ratiociniis in Ludo Ale{\ae}},
+  booktitle = 	 {Exercitationum Mathematicarum Libri Quinque: Quibus accedit {C}hristiani {H}ugenii Tractatus de Ratiociniis in Ale{\ae} Ludo},
+  pages = 	 {517--524},
+  publisher = {Ex officina Johannis Elsevirii},
+  year = 	 {1657},
+  editor = 	 {Schooten, Franciscus {\'a}},
+  address = 	 {Lugd. Batav.},
+}

--- a/test/roots/test-sphinx/bibtex.json
+++ b/test/roots/test-sphinx/bibtex.json
@@ -1,14 +1,14 @@
 {
     "cited": {
-        "index": [
-            "1996:fukuda",
-            "dreze:2000"
-        ],
-        "zbibliography": [
+        "bibliography": [
             "1657:huygens",
             "dreze:2000",
             "rockafellar:1970",
             "1972:savage"
+        ],
+        "index": [
+            "1996:fukuda",
+            "dreze:2000"
         ]
     }
 }

--- a/test/test_cite_brackets.py
+++ b/test/test_cite_brackets.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+"""
+    test_cite_brackets
+    ~~~~~~~~~~~~~~~~~~
+
+    Test custom cite brackets.
+"""
+
+import re
+import pytest
+
+
+@pytest.mark.sphinx('html', testroot='cite_brackets')
+def test_cite_brackets(app, warning):
+    app.build()
+    assert not warning.getvalue()
+    output = (app.outdir / "index.html").read_text(encoding='utf-8')
+    assert "&lt;Huy57&gt;" in output

--- a/test/test_cite_brackets.py
+++ b/test/test_cite_brackets.py
@@ -6,7 +6,6 @@
     Test custom cite brackets.
 """
 
-import re
 import pytest
 
 


### PR DESCRIPTION
See issue #203.

@amichuda Could you briefly test if this works for you as intended? You can add for instance

```python
bibtex_cite_bracket_left = ""
bibtex_cite_bracket_right = ""
```

to your ``conf.py`` to remove the brackets, or assign some other strings to change them.