### PR TITLE
Add type and subtype to warnings

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -88,6 +88,41 @@ the ``sphinxcontrib.bibtex.style.referencing``
 `entry point <https://packaging.python.org/guides/creating-and-discovering-plugins/#using-package-metadata>`_ group.
 See sphinxcontrib-bibtex's own ``setup.py`` script for examples.
 
+Suppressing Warnings
+~~~~~~~~~~~~~~~~~~~~
+
+Warnings from ``sphinxcontrib-bibtex`` can be suppressed by configuring your ``conf.py``
+file. To suppress all warnings from ``sphinxcontrib-bibtex`` (which is probably a bad idea!),
+you could have:
+
+.. code-block:: python
+
+   suppress_warnings = ["bibtex"]
+
+The ``suppress_warnings`` list should of course include warnings from other packages if desired.
+A more practical use case is to suppress warnings of duplicate citations, which might be desirable if you have multiple
+pages in a document that cite the same reference. In that case, you would add to ``conf.py`` the line
+
+.. code-block:: python
+
+   suppress_warnings = ["bibtex.duplicate_citation"]
+
+The complete list of warning subtypes that can be suppressed are listed below:
+
+
+.. code-block:: python
+
+    bibtex.filter_overrides_all
+    bibtex.filter_overrides_notcited
+    bibtex.filter_overrides_cited
+    bibtex.filter_syntax_error
+    bibtex.file_not_configured
+    bibtex.key_not_found
+    bibtex.unknown_list_type
+    bibtex.duplicate_citation
+    bibtex.duplicate_label
+    bibtex.missing_field
+
 Roles and Directives
 --------------------
 

--- a/src/sphinxcontrib/bibtex/directives.py
+++ b/src/sphinxcontrib/bibtex/directives.py
@@ -102,7 +102,8 @@ class BibliographyDirective(Directive):
             if "notcited" in self.options:
                 logger.warning(":filter: overrides :notcited:",
                                location=(env.docname, self.lineno),
-                               type="bibtex", subtype="filter_overrides_notcited")
+                               type="bibtex",
+                               subtype="filter_overrides_notcited")
             if "cited" in self.options:
                 logger.warning(":filter: overrides :cited:",
                                location=(env.docname, self.lineno),
@@ -114,9 +115,8 @@ class BibliographyDirective(Directive):
                     "syntax error in :filter: expression" +
                     " (" + self.options["filter"] + "); "
                     "the option will be ignored",
-                    location=(env.docname, self.lineno,
-                              type="bibtex", subtype="filter_syntax_error")
-                )
+                    location=(env.docname, self.lineno),
+                    type="bibtex", subtype="filter_syntax_error")
                 filter_ = ast.parse("cited")
         elif "all" in self.options:
             filter_ = ast.parse("True")
@@ -134,7 +134,7 @@ class BibliographyDirective(Directive):
                         "{0} not found or not configured"
                         " in bibtex_bibfiles".format(bibfile),
                         location=(env.docname, self.lineno),
-                    type="bibtex", subtype="file_not_configured")
+                        type="bibtex", subtype="file_not_configured")
                 else:
                     bibfiles.append(normbibfile)
         else:
@@ -148,7 +148,7 @@ class BibliographyDirective(Directive):
             logger.warning(
                 "unknown bibliography list type '{0}'.".format(list_),
                 location=(env.docname, self.lineno),
-            type="bibtex", subtype="unknown_list_type")
+                type="bibtex", subtype="unknown_list_type")
             list_ = "citation"
         if list_ in {"bullet", "enumerated"}:
             citation_node_class = docutils.nodes.list_item

--- a/src/sphinxcontrib/bibtex/directives.py
+++ b/src/sphinxcontrib/bibtex/directives.py
@@ -97,13 +97,16 @@ class BibliographyDirective(Directive):
         if "filter" in self.options:
             if "all" in self.options:
                 logger.warning(":filter: overrides :all:",
-                               location=(env.docname, self.lineno))
+                               location=(env.docname, self.lineno),
+                               type="bibtex", subtype="filter_overrides_all")
             if "notcited" in self.options:
                 logger.warning(":filter: overrides :notcited:",
-                               location=(env.docname, self.lineno))
+                               location=(env.docname, self.lineno),
+                               type="bibtex", subtype="filter_overrides_notcited")
             if "cited" in self.options:
                 logger.warning(":filter: overrides :cited:",
-                               location=(env.docname, self.lineno))
+                               location=(env.docname, self.lineno),
+                               type="bibtex", subtype="filter_overrides_cited")
             try:
                 filter_ = ast.parse(self.options["filter"])
             except SyntaxError:
@@ -111,7 +114,8 @@ class BibliographyDirective(Directive):
                     "syntax error in :filter: expression" +
                     " (" + self.options["filter"] + "); "
                     "the option will be ignored",
-                    location=(env.docname, self.lineno)
+                    location=(env.docname, self.lineno,
+                              type="bibtex", subtype="filter_syntax_error")
                 )
                 filter_ = ast.parse("cited")
         elif "all" in self.options:
@@ -129,7 +133,8 @@ class BibliographyDirective(Directive):
                     logger.warning(
                         "{0} not found or not configured"
                         " in bibtex_bibfiles".format(bibfile),
-                        location=(env.docname, self.lineno))
+                        location=(env.docname, self.lineno),
+                    type="bibtex", subtype="file_not_configured")
                 else:
                     bibfiles.append(normbibfile)
         else:
@@ -142,7 +147,8 @@ class BibliographyDirective(Directive):
         if list_ not in {"bullet", "enumerated", "citation"}:
             logger.warning(
                 "unknown bibliography list type '{0}'.".format(list_),
-                location=(env.docname, self.lineno))
+                location=(env.docname, self.lineno),
+            type="bibtex", subtype="unknown_list_type")
             list_ = "citation"
         if list_ in {"bullet", "enumerated"}:
             citation_node_class = docutils.nodes.list_item
@@ -163,7 +169,8 @@ class BibliographyDirective(Directive):
         for key in self.content:
             if keyprefix + key not in citation_nodes:
                 logger.warning('could not find bibtex key "%s"' % key,
-                               location=(env.docname, self.lineno))
+                               location=(env.docname, self.lineno),
+                               type="bibtex", subtype="key_not_found")
             else:
                 keys.append(key)
         # create bibliography object

--- a/src/sphinxcontrib/bibtex/domain.py
+++ b/src/sphinxcontrib/bibtex/domain.py
@@ -388,7 +388,8 @@ class BibtexDomain(Domain):
                 if bibliography.list_ == 'citation' and key in used_keys:
                     logger.warning(
                         'duplicate citation for key "%s"' % key,
-                        location=(bibliography_key.docname, bibliography.line))
+                        location=(bibliography_key.docname, bibliography.line),
+                    type="bibtex", subtype="duplicate_citation")
                 self.citations.append(Citation(
                     citation_id=bibliography.citation_nodes[key]['ids'][0],
                     bibliography_key=bibliography_key,
@@ -408,7 +409,8 @@ class BibtexDomain(Domain):
                                 formatted_entry.label,
                                 used_labels[formatted_entry.label], key),
                             location=(bibliography_key.docname,
-                                      bibliography.line))
+                                      bibliography.line),
+                        type="bibtex", subtype="duplicate_label")
         return []  # expects list of updated docnames
 
     def resolve_xref(self, env: "BuildEnvironment", fromdocname: str,
@@ -424,7 +426,7 @@ class BibtexDomain(Domain):
         for key in keys:
             if key not in citations:
                 logger.warning('could not find bibtex key "%s"' % key,
-                               location=node)
+                               location=node,type="bibtex", subtype="key_not_found")
         plaintext = pybtex.plugin.find_plugin('pybtex.backends', 'plaintext')()
         references = [
             (citation.entry, citation.formatted_entry, SphinxReferenceInfo(
@@ -501,7 +503,8 @@ class BibtexDomain(Domain):
             except ValueError as err:
                 logger.warning(
                     "syntax error in :filter: expression; %s" % err,
-                    location=(bibliography_key.docname, bibliography.line))
+                    location=(bibliography_key.docname, bibliography.line),
+                type="bibtex", subtype="filter_syntax_error")
                 # recover by falling back to the default
                 success = bool(cited_docnames)
             if success or entry.key in bibliography.keys:
@@ -547,7 +550,8 @@ class BibtexDomain(Domain):
             except FieldIsMissing as exc:
                 logger.warning(
                     str(exc),
-                    location=(bibliography_key.docname, bibliography.line))
+                    location=(bibliography_key.docname, bibliography.line),
+                type="bibtex", subtype="missing_field")
                 yield(
                     entry,
                     FormattedEntry(entry.key, Tag('b', str(exc)),

--- a/src/sphinxcontrib/bibtex/domain.py
+++ b/src/sphinxcontrib/bibtex/domain.py
@@ -389,7 +389,7 @@ class BibtexDomain(Domain):
                     logger.warning(
                         'duplicate citation for key "%s"' % key,
                         location=(bibliography_key.docname, bibliography.line),
-                    type="bibtex", subtype="duplicate_citation")
+                        type="bibtex", subtype="duplicate_citation")
                 self.citations.append(Citation(
                     citation_id=bibliography.citation_nodes[key]['ids'][0],
                     bibliography_key=bibliography_key,
@@ -410,7 +410,7 @@ class BibtexDomain(Domain):
                                 used_labels[formatted_entry.label], key),
                             location=(bibliography_key.docname,
                                       bibliography.line),
-                        type="bibtex", subtype="duplicate_label")
+                            type="bibtex", subtype="duplicate_label")
         return []  # expects list of updated docnames
 
     def resolve_xref(self, env: "BuildEnvironment", fromdocname: str,
@@ -426,7 +426,8 @@ class BibtexDomain(Domain):
         for key in keys:
             if key not in citations:
                 logger.warning('could not find bibtex key "%s"' % key,
-                               location=node,type="bibtex", subtype="key_not_found")
+                               location=node, type="bibtex",
+                               subtype="key_not_found")
         plaintext = pybtex.plugin.find_plugin('pybtex.backends', 'plaintext')()
         references = [
             (citation.entry, citation.formatted_entry, SphinxReferenceInfo(
@@ -504,7 +505,7 @@ class BibtexDomain(Domain):
                 logger.warning(
                     "syntax error in :filter: expression; %s" % err,
                     location=(bibliography_key.docname, bibliography.line),
-                type="bibtex", subtype="filter_syntax_error")
+                    type="bibtex", subtype="filter_syntax_error")
                 # recover by falling back to the default
                 success = bool(cited_docnames)
             if success or entry.key in bibliography.keys:
@@ -551,7 +552,7 @@ class BibtexDomain(Domain):
                 logger.warning(
                     str(exc),
                     location=(bibliography_key.docname, bibliography.line),
-                type="bibtex", subtype="missing_field")
+                    type="bibtex", subtype="missing_field")
                 yield(
                     entry,
                     FormattedEntry(entry.key, Tag('b', str(exc)),

--- a/src/sphinxcontrib/bibtex/foot_roles.py
+++ b/src/sphinxcontrib/bibtex/foot_roles.py
@@ -109,7 +109,8 @@ class FootCiteRole(XRefRole):
                     foot_new_refs.add(key)
             else:
                 logger.warning('could not find bibtex key "%s"' % key,
-                               location=(env.docname, self.lineno))
+                               location=(env.docname, self.lineno),
+                               type="bibtex", subtype="key_not_found")
         ref_nodes = format_references(
             foot_domain.reference_style, FootReferenceText, node['reftype'],
             references).render(domain.backend)


### PR DESCRIPTION
I’ve modified the logger.warning commands to include the fields
type (always “bibtex”) and subtype. This allows warnings to be 
suppressed if desired in Sphinx. For example, setting

suppress_warnings = [“bibtex.duplicate_citation”]

will eliminate warnings about duplicate citations. These warnings can be
annoying in some use cases where the same citation might be desired on
multiple pages. While users are unlikely to suppress some of the other
warnings, i’ve include a type and subtype for each warning to make it
possible to do so. All available warning type to suppress are:

	bibtex.filter_overrides_all
	bibtex.filter_overrides_notcited
	bibtex.filter_overrides_cited
	bibtex.filter_syntax_error
	bibtex.file_not_configured
	bibtex.key_not_found
	bibtex.unknown_list_type
	bibtex.duplicate_citation
	bibtex.duplicate_label
	bibtex.missing_field