### PR TITLE
Use container node for citation nodes to respect docutils spec.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 2.4.2 (in development)
 ----------------------
 
+* Use container node instead of paragraph node for containing bibliographies,
+  fixing a violation against the docutils spec
+  (see issue #273, reported by rappdw, with additional input from brechtm).
+
 2.4.1 (10 September 2021)
 -------------------------
 

--- a/src/sphinxcontrib/bibtex/domain.py
+++ b/src/sphinxcontrib/bibtex/domain.py
@@ -289,7 +289,7 @@ class BibtexDomain(Domain):
             encoding='',
             bibfiles={},
             data=pybtex.database.BibliographyData()),
-        bibliography_header=docutils.nodes.compound(),
+        bibliography_header=docutils.nodes.container(),
         bibliographies={},
         citations=[],
         citation_refs=[],

--- a/src/sphinxcontrib/bibtex/domain.py
+++ b/src/sphinxcontrib/bibtex/domain.py
@@ -289,7 +289,7 @@ class BibtexDomain(Domain):
             encoding='',
             bibfiles={},
             data=pybtex.database.BibliographyData()),
-        bibliography_header=docutils.nodes.paragraph(),
+        bibliography_header=docutils.nodes.compound(),
         bibliographies={},
         citations=[],
         citation_refs=[],
@@ -350,7 +350,7 @@ class BibtexDomain(Domain):
         # parse bibliography header
         header = getattr(env.app.config, "bibtex_bibliography_header")
         if header:
-            self.data["bibliography_header"] = \
+            self.data["bibliography_header"] += \
                 parse_header(header, "bibliography_header")
 
     def clear_doc(self, docname: str) -> None:

--- a/src/sphinxcontrib/bibtex/foot_domain.py
+++ b/src/sphinxcontrib/bibtex/foot_domain.py
@@ -35,7 +35,7 @@ class BibtexFootDomain(Domain):
     label = 'BibTeX Footnote Citations'
     data_version = 0
     initial_data = dict(
-        bibliography_header=docutils.nodes.paragraph(),
+        bibliography_header=docutils.nodes.compound(),
     )
     reference_style: BaseReferenceStyle
 
@@ -60,7 +60,7 @@ class BibtexFootDomain(Domain):
         # parse bibliography header
         header = getattr(env.app.config, "bibtex_footbibliography_header")
         if header:
-            self.data["bibliography_header"] = \
+            self.data["bibliography_header"] += \
                 parse_header(header, "foot_bibliography_header")
 
     def merge_domaindata(self, docnames: List[str], otherdata: Dict) -> None:

--- a/src/sphinxcontrib/bibtex/foot_domain.py
+++ b/src/sphinxcontrib/bibtex/foot_domain.py
@@ -35,7 +35,7 @@ class BibtexFootDomain(Domain):
     label = 'BibTeX Footnote Citations'
     data_version = 0
     initial_data = dict(
-        bibliography_header=docutils.nodes.compound(),
+        bibliography_header=docutils.nodes.container(),
     )
     reference_style: BaseReferenceStyle
 

--- a/test/common.py
+++ b/test/common.py
@@ -22,7 +22,7 @@ def html_citation_refs(refid=RE_ID, label=RE_LABEL, title=RE_TITLE):
 
 def html_citations(id_=RE_ID, label=RE_LABEL, text=RE_TEXT):
     return re.compile(
-        r'<dt class=".*label.*" id="(?P<id_>{id_})">'
+        r'<dt class="label" id="(?P<id_>{id_})">'
         r'<span class="brackets">'
         r'(?:<a class="fn-backref" href="#(?P<backref>{backref_id})">)?'
         r'(?P<label>{label})'
@@ -49,7 +49,7 @@ def html_footnote_refs(refid=RE_ID):
 
 def html_footnotes(id_=RE_ID, text=RE_TEXT):
     return re.compile(
-        r'<dt class=".*label.*" id="(?P<id_>{id_})">'
+        r'<dt class="label" id="(?P<id_>{id_})">'
         r'<span class="brackets">'
         r'(?:<a class="fn-backref" href="#(?P<backref>{backref_id})">)?'
         r'(?P<label>{label})'

--- a/test/common.py
+++ b/test/common.py
@@ -22,7 +22,7 @@ def html_citation_refs(refid=RE_ID, label=RE_LABEL, title=RE_TITLE):
 
 def html_citations(id_=RE_ID, label=RE_LABEL, text=RE_TEXT):
     return re.compile(
-        r'<dt class="label" id="(?P<id_>{id_})">'
+        r'<dt class=".*label.*" id="(?P<id_>{id_})">'
         r'<span class="brackets">'
         r'(?:<a class="fn-backref" href="#(?P<backref>{backref_id})">)?'
         r'(?P<label>{label})'
@@ -49,7 +49,7 @@ def html_footnote_refs(refid=RE_ID):
 
 def html_footnotes(id_=RE_ID, text=RE_TEXT):
     return re.compile(
-        r'<dt class="label" id="(?P<id_>{id_})">'
+        r'<dt class=".*label.*" id="(?P<id_>{id_})">'
         r'<span class="brackets">'
         r'(?:<a class="fn-backref" href="#(?P<backref>{backref_id})">)?'
         r'(?P<label>{label})'

--- a/test/test_bibliography.py
+++ b/test/test_bibliography.py
@@ -163,7 +163,7 @@ def test_bibliography_multi_foot(app, warning) -> None:
     app.build()
     assert not warning.getvalue()
     output = (app.outdir / "index.html").read_text(encoding='utf-8')
-    assert output.count('<p class="rubric"') == 3
+    assert len(re.findall('<p class=".*rubric.*"', output)) == 3
     assert len(re.findall(
         html_footnotes(id_="footcite-2009-mandel"), output)) == 1
     assert len(re.findall(
@@ -233,10 +233,10 @@ def test_bibliography_custom_ids(app, warning) -> None:
     app.build()
     assert not warning.getvalue()
     output = (app.outdir / "index.html").read_text(encoding='utf-8')
-    assert '<p id="bibliography-id-1">' in output
-    assert '<p id="bibliography-id-2">' in output
-    assert '<p id="footbibliography-id-1">' in output
-    assert '<p id="footbibliography-id-2">' in output
+    assert ' id="bibliography-id-1">' in output
+    assert ' id="bibliography-id-2">' in output
+    assert ' id="footbibliography-id-1">' in output
+    assert ' id="footbibliography-id-2">' in output
     match1 = html_citations(text='.*Evensen.*').search(output)
     match2 = html_citations(text='.*Mandel.*').search(output)
     match3 = html_citations(text='.*Lorenc.*').search(output)

--- a/test/test_bibliography.py
+++ b/test/test_bibliography.py
@@ -163,7 +163,7 @@ def test_bibliography_multi_foot(app, warning) -> None:
     app.build()
     assert not warning.getvalue()
     output = (app.outdir / "index.html").read_text(encoding='utf-8')
-    assert len(re.findall('<p class="rubric"', output)) == 3
+    assert output.count('<p class="rubric"') == 3
     assert len(re.findall(
         html_footnotes(id_="footcite-2009-mandel"), output)) == 1
     assert len(re.findall(

--- a/test/test_bibliography.py
+++ b/test/test_bibliography.py
@@ -163,7 +163,7 @@ def test_bibliography_multi_foot(app, warning) -> None:
     app.build()
     assert not warning.getvalue()
     output = (app.outdir / "index.html").read_text(encoding='utf-8')
-    assert len(re.findall('<p class=".*rubric.*"', output)) == 3
+    assert len(re.findall('<p class="rubric"', output)) == 3
     assert len(re.findall(
         html_footnotes(id_="footcite-2009-mandel"), output)) == 1
     assert len(re.findall(
@@ -233,10 +233,10 @@ def test_bibliography_custom_ids(app, warning) -> None:
     app.build()
     assert not warning.getvalue()
     output = (app.outdir / "index.html").read_text(encoding='utf-8')
-    assert ' id="bibliography-id-1">' in output
-    assert ' id="bibliography-id-2">' in output
-    assert ' id="footbibliography-id-1">' in output
-    assert ' id="footbibliography-id-2">' in output
+    assert ' id="bibliography-id-1"' in output
+    assert ' id="bibliography-id-2"' in output
+    assert ' id="footbibliography-id-1"' in output
+    assert ' id="footbibliography-id-2"' in output
     match1 = html_citations(text='.*Evensen.*').search(output)
     match2 = html_citations(text='.*Mandel.*').search(output)
     match3 = html_citations(text='.*Lorenc.*').search(output)

--- a/test/test_debug.py
+++ b/test/test_debug.py
@@ -24,7 +24,7 @@ bibtex_citation_xml = """
             <reference internal="True" refid="id3" reftitle="The title.">
                 tes
             ]
-    <paragraph ids="id2">
+    <compound ids="id2">
         <citation backrefs="id1" docname="index" ids="id3">
             <label support_smartquotes="False">
                 tes
@@ -89,7 +89,7 @@ def test_debug_minimal_example(app, warning) -> None:
         '                Nel87',
         '            ]',
         '        .',
-        '    <paragraph ids="id3">',
+        '    <compound ids="id3">',
         '        <citation backrefs="id1 id2" docname="index" ids="id4">',
         '            <label support_smartquotes="False">',
         '                Nel87',

--- a/test/test_debug.py
+++ b/test/test_debug.py
@@ -24,7 +24,7 @@ bibtex_citation_xml = """
             <reference internal="True" refid="id3" reftitle="The title.">
                 tes
             ]
-    <compound ids="id2">
+    <container ids="id2">
         <citation backrefs="id1" docname="index" ids="id3">
             <label support_smartquotes="False">
                 tes
@@ -89,7 +89,7 @@ def test_debug_minimal_example(app, warning) -> None:
         '                Nel87',
         '            ]',
         '        .',
-        '    <compound ids="id3">',
+        '    <container ids="id3">',
         '        <citation backrefs="id1 id2" docname="index" ids="id4">',
         '            <label support_smartquotes="False">',
         '                Nel87',


### PR DESCRIPTION
See #273.

@rappdw Could you give this a spin and see if this fixes your issue? It uses a compound node, but it would be easy to replace that with something else. One thing I've noticed is that the compound node adds some extra attributes to the html, so I'm not sure if it is suitable for purpose. But it appears to work.