### PR TITLE
Add new cit_ref_label style for generating citation_reference nodes

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,7 +17,7 @@ jobs:
         pip-sphinx: [sphinx]
         include:
           - python-version: 3.9
-            pip-sphinx: 'sphinx==2.1 docutils==0.16 jinja2<3.1'
+            pip-sphinx: '"sphinx==2.1 docutils==0.16 jinja2<3.1"'
           - python-version: 3.9
             pip-sphinx: --pre sphinx
     steps:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,7 +17,7 @@ jobs:
         pip-sphinx: [sphinx]
         include:
           - python-version: 3.9
-            pip-sphinx: sphinx==2.1 docutils==0.16
+            pip-sphinx: sphinx==2.1 docutils==0.16 jinja2<3.1
           - python-version: 3.9
             pip-sphinx: --pre sphinx
     steps:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,7 +17,7 @@ jobs:
         pip-sphinx: [sphinx]
         include:
           - python-version: 3.9
-            pip-sphinx: sphinx==2.1 docutils==0.16 jinja2<3.1
+            pip-sphinx: 'sphinx==2.1 docutils==0.16 jinja2<3.1'
           - python-version: 3.9
             pip-sphinx: --pre sphinx
     steps:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,7 +17,7 @@ jobs:
         pip-sphinx: [sphinx]
         include:
           - python-version: 3.9
-            pip-sphinx: '"sphinx==2.1 docutils==0.16 jinja2<3.1"'
+            pip-sphinx: '"sphinx==2.1" "docutils==0.16" "jinja2<3.1"'
           - python-version: 3.9
             pip-sphinx: --pre sphinx
     steps:

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ setup(
             plugin('label'),
             plugin('super', 'super_'),
             plugin('foot'),
+            plugin('cit_ref_label'),
         ],
     }
 )

--- a/src/sphinxcontrib/bibtex/style/referencing/cit_ref_label.py
+++ b/src/sphinxcontrib/bibtex/style/referencing/cit_ref_label.py
@@ -1,0 +1,46 @@
+from dataclasses import dataclass, field
+from typing import Union, TYPE_CHECKING
+
+from sphinxcontrib.bibtex.style.referencing import (
+    BracketStyle, PersonStyle, GroupReferenceStyle
+)
+from .basic_cit_ref_label import (
+    BasicCitRefLabelParentheticalReferenceStyle,
+    BasicCitRefLabelTextualReferenceStyle,
+)
+from .extra_empty import ExtraEmptyReferenceStyle
+
+if TYPE_CHECKING:
+    from pybtex.richtext import BaseText
+
+
+@dataclass
+class CitRefLabelReferenceStyle(GroupReferenceStyle):
+    """Textual or parenthetical reference by label,
+    or just by author, label, or year.
+    """
+
+    #: Bracket style for textual citations (:cite:t: and variations).
+    #: Note: brackets are ignored, only separators are used.
+    bracket_textual: BracketStyle = field(default_factory=BracketStyle)
+
+    #: Person style.
+    person: PersonStyle = field(default_factory=PersonStyle)
+
+    #: Separator between labels for parenthetical citations.
+    label_sep_parenthetical: Union["BaseText", str] = ' '
+
+    #: Separator between text and reference for textual citations.
+    text_reference_sep: Union["BaseText", str] = ' '
+
+    def __post_init__(self):
+        self.styles.extend([
+            BasicCitRefLabelParentheticalReferenceStyle(),
+            BasicCitRefLabelTextualReferenceStyle(
+                bracket=self.bracket_textual,
+                person=self.person,
+                text_reference_sep=self.text_reference_sep,
+            ),
+            ExtraEmptyReferenceStyle(),
+        ])
+        super().__post_init__()

--- a/src/sphinxcontrib/bibtex/style/template.py
+++ b/src/sphinxcontrib/bibtex/style/template.py
@@ -171,16 +171,20 @@ def make_citation_reference_node(
         ) -> docutils.nodes.citation_reference:
     """Shortcut to create a citation reference node."""
     # latex builder needs docname and refname
-    node = docutils.nodes.citation_reference(
-        '', '', internal=True, docname=todocname, refname=targetid)
-    if fromdocname == todocname and targetid:
-        node['refid'] = targetid
+    node = docutils.nodes.citation_reference('', '', internal=True)
+    if builder.name in {'latex', 'rinoh'}:
+        # builders using docname/refname
+        node['docname'] = todocname
+        node['refname'] = targetid
     else:
-        if targetid:
-            node['refuri'] = (builder.get_relative_uri(fromdocname, todocname) +
-                              '#' + targetid)
+        # builders using refid/refuri
+        if fromdocname == todocname:
+            node['refid'] = targetid
         else:
-            node['refuri'] = builder.get_relative_uri(fromdocname, todocname)
+            # note: citation_reference visitor in html builder ignores refuri
+            # attribute; this is a docutils bug
+            node['refuri'] = (builder.get_relative_uri(fromdocname, todocname)
+                              + '#' + targetid)
     if title:
         node['reftitle'] = title
     node += child

--- a/src/sphinxcontrib/bibtex/style/template.py
+++ b/src/sphinxcontrib/bibtex/style/template.py
@@ -162,7 +162,7 @@ def reference(children, data: Dict[str, Any]):
     return SphinxReferenceText(info, *parts)
 
 
-# copy-pasted from sphinx's make_refnode
+# based on sphinx's make_refnode
 # to create citation_reference instead of reference
 def make_citation_reference_node(
         builder: "Builder", fromdocname: str, todocname: str,
@@ -170,7 +170,9 @@ def make_citation_reference_node(
         child: Union[Node, List[Node]], title: str = None
         ) -> docutils.nodes.citation_reference:
     """Shortcut to create a citation reference node."""
-    node = docutils.nodes.citation_reference('', '', internal=True)
+    # latex builder needs docname and refname
+    node = docutils.nodes.citation_reference(
+        '', '', internal=True, docname=todocname, refname=targetid)
     if fromdocname == todocname and targetid:
         node['refid'] = targetid
     else:

--- a/test/roots/test-citation_roles_2/conf.py
+++ b/test/roots/test-citation_roles_2/conf.py
@@ -1,0 +1,3 @@
+extensions = ['sphinxcontrib.bibtex']
+exclude_patterns = ['_build']
+bibtex_bibfiles = ['refs.bib']

--- a/test/roots/test-citation_roles_2/conf.py
+++ b/test/roots/test-citation_roles_2/conf.py
@@ -1,3 +1,4 @@
 extensions = ['sphinxcontrib.bibtex']
 exclude_patterns = ['_build']
 bibtex_bibfiles = ['refs.bib']
+bibtex_reference_style = 'cit_ref_label'

--- a/test/roots/test-citation_roles_2/index.rst
+++ b/test/roots/test-citation_roles_2/index.rst
@@ -1,6 +1,10 @@
 Contents
 ========
 
+.. toctree::
+
+   other
+
 Single Citations
 ----------------
 

--- a/test/roots/test-citation_roles_2/index.rst
+++ b/test/roots/test-citation_roles_2/index.rst
@@ -48,7 +48,11 @@ role                   result
 
 :cite:empty:`testseven`
 
+[EIGHT2008]_
+
 Bibliography
 ------------
 
 .. bibliography::
+
+.. [EIGHT2008] Regular citation.

--- a/test/roots/test-citation_roles_2/index.rst
+++ b/test/roots/test-citation_roles_2/index.rst
@@ -1,0 +1,54 @@
+Contents
+========
+
+Single Citations
+----------------
+
+====================== ====================================================
+role                   result
+====================== ====================================================
+``:cite:p:``           :cite:p:`testthree`
+``:cite:ps:``          :cite:ps:`testthree`
+``:cite:t:``           :cite:t:`testthree`
+``:cite:ts:``          :cite:ts:`testthree`
+``:cite:ct:``          :cite:ct:`testthree`
+``:cite:cts:``         :cite:cts:`testthree`
+``:cite:empty:``       AAA :cite:empty:`testthree` AAA
+====================== ====================================================
+
+Double Citations
+----------------
+
+====================== ====================================================
+role                   result
+====================== ====================================================
+``:cite:p:``           :cite:p:`testone,testtwo`
+``:cite:ps:``          :cite:ps:`testone,testtwo`
+``:cite:t:``           :cite:t:`testone,testtwo`
+``:cite:ts:``          :cite:ts:`testone,testtwo`
+``:cite:ct:``          :cite:ct:`testone,testtwo`
+``:cite:cts:``         :cite:cts:`testone,testtwo`
+``:cite:empty:``       BBB :cite:empty:`testone,testtwo` BBB
+====================== ====================================================
+
+Triple Citations
+----------------
+
+====================== ====================================================
+role                   result
+====================== ====================================================
+``:cite:p:``           :cite:p:`testfour,testfive,testsix`
+``:cite:ps:``          :cite:ps:`testfour,testfive,testsix`
+``:cite:t:``           :cite:t:`testfour,testfive,testsix`
+``:cite:ts:``          :cite:ts:`testfour,testfive,testsix`
+``:cite:ct:``          :cite:ct:`testfour,testfive,testsix`
+``:cite:cts:``         :cite:cts:`testfour,testfive,testsix`
+``:cite:empty:``       CCC :cite:empty:`testfour,testfive,testsix` CCC
+====================== ====================================================
+
+:cite:empty:`testseven`
+
+Bibliography
+------------
+
+.. bibliography::

--- a/test/roots/test-citation_roles_2/other.rst
+++ b/test/roots/test-citation_roles_2/other.rst
@@ -1,0 +1,6 @@
+Other Document
+==============
+
+:cite:p:`testfour,testfive,testsix`
+
+[EIGHT2008]_

--- a/test/roots/test-citation_roles_2/refs.bib
+++ b/test/roots/test-citation_roles_2/refs.bib
@@ -1,0 +1,41 @@
+@Misc{testone,
+  author = {Ad al Ap},
+  title = {TestOne},
+  year = 2001
+}
+
+@Misc{testtwo,
+  author = {Bo Be and Cy Ci},
+  title = {TestTwo},
+  year = 2002
+}
+
+@Misc{testthree,
+  author =    {Do de Du and Ed Em and Fo Fa},
+  title =     {TestThree},
+  year = 2003
+}
+
+@Misc{testfour,
+  author =    {Ga Ge},
+  title =     {TestFour},
+  year = 2004
+}
+
+@Misc{testfive,
+  author =    {Ho Hu},
+  title =     {TestFive},
+  year = 2005
+}
+
+@Misc{testsix,
+  author =    {Ip Ix},
+  title =     {TestSix},
+  year = 2006
+}
+
+@Misc{testseven,
+  author =    {Jo Ju},
+  title =     {TestSeven},
+  year = 2007
+}

--- a/test/test_citation.py
+++ b/test/test_citation.py
@@ -275,6 +275,22 @@ def test_citation_roles_cit_ref(app, warning) -> None:
 
 
 @pytest.mark.sphinx(
+    'html', testroot='citation_roles_2',
+    confoverrides={'bibtex_reference_style': 'cit_ref_label'})
+def test_citation_roles_cit_ref_html(app, warning) -> None:
+    app.build()
+    assert not warning.getvalue()
+
+
+@pytest.mark.sphinx(
+    'latex', testroot='citation_roles_2',
+    confoverrides={'bibtex_reference_style': 'cit_ref_label'})
+def test_citation_roles_cit_ref_latex(app, warning) -> None:
+    app.build()
+    assert not warning.getvalue()
+
+
+@pytest.mark.sphinx(
     'html', testroot='citation_roles',
     confoverrides={'bibtex_default_style': 'plain',
                    'bibtex_reference_style': 'super'})

--- a/test/test_citation.py
+++ b/test/test_citation.py
@@ -236,9 +236,12 @@ def test_citation_roles_authoryear(app, warning) -> None:
     assert "[Ju07] Jo Ju. Testseven. 2007." in output
 
 
+# note: disabling tooltips here to cover extra code path
+# not used for text builder anyway
 @pytest.mark.sphinx(
     'text', testroot='citation_roles_2',
-    confoverrides={'bibtex_reference_style': 'cit_ref_label'})
+    confoverrides={'bibtex_reference_style': 'cit_ref_label',
+                   'bibtex_tooltips': False})
 def test_citation_roles_cit_ref(app, warning) -> None:
     app.build()
     assert not warning.getvalue()

--- a/test/test_citation.py
+++ b/test/test_citation.py
@@ -237,6 +237,44 @@ def test_citation_roles_authoryear(app, warning) -> None:
 
 
 @pytest.mark.sphinx(
+    'text', testroot='citation_roles_2',
+    confoverrides={'bibtex_reference_style': 'cit_ref_label'})
+def test_citation_roles_cit_ref(app, warning) -> None:
+    app.build()
+    assert not warning.getvalue()
+    output = (app.outdir / "index.txt").read_text()
+    tests = [
+        ("p",           " [dDEF03] "),
+        ("ps",          " [dDEF03] "),
+        ("t",           " de Du *et al.* [dDEF03] "),
+        ("ts",          " de Du, Em, and Fa [dDEF03] "),
+        ("ct",          " De Du *et al.* [dDEF03] "),
+        ("cts",         " De Du, Em, and Fa [dDEF03] "),
+        ("empty",       " AAA  AAA "),
+        ("p",           " [aA01] [BC02] "),
+        ("ps",          " [aA01] [BC02] "),
+        ("t",           " al Ap [aA01], Be and Ci [BC02] "),
+        ("ts",          " al Ap [aA01], Be and Ci [BC02] "),
+        ("ct",          " Al Ap [aA01], Be and Ci [BC02] "),
+        ("cts",         " Al Ap [aA01], Be and Ci [BC02] "),
+        ("empty",       " BBB  BBB "),
+        ("p",           " [Ge04] [Hu05] [Ix06] "),
+        ("ps",          " [Ge04] [Hu05] [Ix06] "),
+        ("t",           " Ge [Ge04], Hu [Hu05], Ix [Ix06] "),
+        ("ts",          " Ge [Ge04], Hu [Hu05], Ix [Ix06] "),
+        ("ct",          " Ge [Ge04], Hu [Hu05], Ix [Ix06] "),
+        ("cts",         " Ge [Ge04], Hu [Hu05], Ix [Ix06] "),
+        ("empty", " CCC  CCC "),
+    ]
+    for role, text in tests:
+        escaped_text = re.escape(text)
+        pattern = f'":cite:{role}:".*{escaped_text}'
+        assert re.search(pattern, output) is not None
+    # check :cite:empty: generates citation
+    assert "[Ju07] Jo Ju. Testseven. 2007." in output
+
+
+@pytest.mark.sphinx(
     'html', testroot='citation_roles',
     confoverrides={'bibtex_default_style': 'plain',
                    'bibtex_reference_style': 'super'})


### PR DESCRIPTION
See issue #275 

@brechtm Could you give this branch a spin? You'll need to render with the cit_ref_label style. As a test document, to check that all citations are correctly rendered, you can use https://github.com/mcmtroffaes/sphinxcontrib-bibtex/tree/feature/generate-citation-reference-2/test/roots/test-citation_roles_2