### PR TITLE
generate citation_reference nodes for rinoh builder

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -34,7 +34,7 @@ jobs:
         pip install .
     - name: Install extra dependencies
       run: |
-        python -m pip install flake8 check-manifest mypy types-setuptools types-docutils
+        python -m pip install flake8 check-manifest mypy types-setuptools types-docutils rinohtype
       if: matrix.pip-sphinx == 'sphinx' && matrix.python-version == '3.9'
     - name: Check manifest
       run: |

--- a/src/sphinxcontrib/bibtex/style/template.py
+++ b/src/sphinxcontrib/bibtex/style/template.py
@@ -132,6 +132,13 @@ class SphinxReferenceText(BaseReferenceText[SphinxReferenceInfo]):
                 + super().render(backend)
                 + [raw_latex('}')]
             )
+        elif info.builder.name == 'rinoh':
+            key = f'%{info.todocname}#{info.citation_id}'
+            children = super().render(backend)
+            refnode = docutils.nodes.citation_reference(
+                text=children[0], refid=key, reftitle=info.title)
+            refnode.extend(children[1:])
+            return [refnode]
         else:
             children = super().render(backend)
             # make_refnode only takes a single child

--- a/test/roots/test-citation_rinoh/conf.py
+++ b/test/roots/test-citation_rinoh/conf.py
@@ -1,0 +1,7 @@
+extensions = ['rinoh.frontend.sphinx', 'sphinxcontrib.bibtex']
+exclude_patterns = ['_build']
+bibtex_bibfiles = ['test.bib']
+rinoh_documents = [
+    dict(doc='index', target='book', toctree_only=False,
+         template='template.rtt'),
+]

--- a/test/roots/test-citation_rinoh/index.rst
+++ b/test/roots/test-citation_rinoh/index.rst
@@ -1,0 +1,3 @@
+:cite:`testkey`
+
+.. bibliography::

--- a/test/roots/test-citation_rinoh/ssheet.rts
+++ b/test/roots/test-citation_rinoh/ssheet.rts
@@ -1,0 +1,9 @@
+[STYLESHEET]
+base = sphinx_base14
+
+[citation]
+location = in-place
+
+[citation marker]
+label_prefix=''
+label_suffix=''

--- a/test/roots/test-citation_rinoh/template.rtt
+++ b/test/roots/test-citation_rinoh/template.rtt
@@ -1,0 +1,7 @@
+[TEMPLATE_CONFIGURATION]
+name=btex
+template=article
+stylesheet=ssheet.rts
+
+[VARIABLES]
+paper_size=A5

--- a/test/roots/test-citation_rinoh/test.bib
+++ b/test/roots/test-citation_rinoh/test.bib
@@ -1,0 +1,3 @@
+@Misc{testkey,
+title = {The Title}
+}

--- a/test/test_citation.py
+++ b/test/test_citation.py
@@ -424,3 +424,13 @@ def test_citation_tooltip3(app, warning) -> None:
     assert len(html_citations(label='tes').findall(output)) == 1
     assert len(html_citation_refs(
         label='tes', title='whoop whoop').findall(output)) == 1
+
+
+@pytest.mark.sphinx('rinoh', testroot='citation_rinoh')
+def test_citation_rinoh(app, warning) -> None:
+    app.build()
+    assert not warning.getvalue()
+    # output = (app.outdir / "index.html").read_text()
+    # assert len(html_citations(label='tes').findall(output)) == 1
+    # assert len(html_citation_refs(
+    #     label='tes', title=r"The title\.").findall(output)) == 1


### PR DESCRIPTION
@brechtm Take 3 as discussed.

I do have one issue that I cannot run the rinoh builder to test this, getting this error:

```
...\test\roots\test-citation_rinoh> python -m sphinx -b rinoh . _build/
    return _compile(pattern, flags).sub(repl, string, count)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: expected string or bytes-like object, got 'NoneType'
The full traceback has been saved in ***\sphinx-err-9ca3m_zd.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
```

Here's the full log. Any clue?

```
# Sphinx version: 4.4.0
# Python version: 3.11.0a5 (CPython)
# Docutils version: 0.17.1 release
# Jinja2 version: 3.0.3
# Last messages:

# Loaded extensions:
Traceback (most recent call last):
  File "***\Python311\Lib\contextlib.py", line 155, in __exit__
    self.gen.throw(typ, value, traceback)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "***\Python311\Lib\contextlib.py", line 155, in __exit__
    self.gen.throw(typ, value, traceback)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "***\sphinxcontrib-bibtex\venv311\Lib\site-packages\sphinx\util\docutils.py", line 140, in patched_get_language
    yield
    ^^^^^
  File "***\Python311\Lib\contextlib.py", line 155, in __exit__
    self.gen.throw(typ, value, traceback)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "***\sphinxcontrib-bibtex\venv311\Lib\site-packages\sphinx\util\docutils.py", line 154, in using_user_docutils_conf
    yield
    ^^^^^
  File "***\sphinxcontrib-bibtex\venv311\Lib\site-packages\sphinx\util\docutils.py", line 166, in patch_docutils
    yield
    ^^^^^
  File "***\Python311\Lib\contextlib.py", line 155, in __exit__
    self.gen.throw(typ, value, traceback)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "***\sphinxcontrib-bibtex\venv311\Lib\site-packages\sphinx\util\docutils.py", line 55, in docutils_namespace
    yield
    ^^^^^
  File "***\sphinxcontrib-bibtex\venv311\Lib\site-packages\sphinx\cmd\build.py", line 280, in build_main
    app = Sphinx(args.sourcedir, args.confdir, args.outputdir,
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "***\sphinxcontrib-bibtex\venv311\Lib\site-packages\sphinx\application.py", line 230, in __init__
    self.setup_extension(extension)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "***\sphinxcontrib-bibtex\venv311\Lib\site-packages\sphinx\application.py", line 387, in setup_extension
    self.registry.load_extension(self, extname)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "***\Python311\Lib\contextlib.py", line 155, in __exit__
    self.gen.throw(typ, value, traceback)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "***\sphinxcontrib-bibtex\venv311\Lib\site-packages\sphinx\util\logging.py", line 338, in prefixed_warnings
    yield
    ^^^^^
  File "***\sphinxcontrib-bibtex\venv311\Lib\site-packages\sphinx\registry.py", line 433, in load_extension
    mod = import_module(extname)
          ^^^^^^^^^^^^^^^^^^^^^^
  File "***\Python311\Lib\importlib\__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1206, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1178, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1128, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1206, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1178, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1128, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1206, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1178, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1149, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 924, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "***\sphinxcontrib-bibtex\venv311\Lib\site-packages\rinoh\__init__.py", line 41, in <module>
    from . import resource
    ^^^^^^^^^^^^^^^^^^^^^^
  File "***\sphinxcontrib-bibtex\venv311\Lib\site-packages\rinoh\resource.py", line 205, in <module>
    from .template import DocumentTemplate
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "***\sphinxcontrib-bibtex\venv311\Lib\site-packages\rinoh\template.py", line 42, in <module>
    from .stylesheets import sphinx
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "***\sphinxcontrib-bibtex\venv311\Lib\site-packages\rinoh\stylesheets\__init__.py", line 42, in <module>
    .format(stylesheet.description, stylesheet))
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "***\sphinxcontrib-bibtex\venv311\Lib\site-packages\rinoh\style.py", line 670, in __str__
    for name, entry_point in self.installed_resources:
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "***\sphinxcontrib-bibtex\venv311\Lib\site-packages\rinoh\resource.py", line 54, in installed_resources
    for entry_point in ilm.entry_points()[cls.entry_point_group]:
                       ^^^^^^^^^^^^^^^^^^
  File "***\Python311\Lib\importlib\metadata\__init__.py", line 993, in entry_points
    return SelectableGroups.load(eps).select(**params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "***\Python311\Lib\importlib\metadata\__init__.py", line 448, in load
    ordered = sorted(eps, key=by_group)
              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "***\Python311\Lib\importlib\metadata\__init__.py", line 990, in <genexpr>
    eps = itertools.chain.from_iterable(
                                       ^
  File "***\Python311\Lib\importlib\metadata\_itertools.py", line 16, in unique_everseen
    k = key(element)
        ^^^^^^^^^^^^
  File "***\Python311\Lib\importlib\metadata\__init__.py", line 599, in _normalized_name
    return Prepared.normalize(self.name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "***\Python311\Lib\importlib\metadata\__init__.py", line 855, in normalize
    return re.sub(r"[-_.]+", "-", name).lower().replace('-', '_')
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "***\Python311\Lib\re.py", line 189, in sub
    return _compile(pattern, flags).sub(repl, string, count)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: expected string or bytes-like object, got 'NoneType'
```