### PR TITLE
Add post-transform to fix italics formatting in citations

### DIFF
--- a/src/sphinxcontrib/bibtex/__init__.py
+++ b/src/sphinxcontrib/bibtex/__init__.py
@@ -11,7 +11,7 @@ from .foot_domain import BibtexFootDomain
 from .nodes import bibliography, raw_latex, visit_raw_latex, depart_raw_latex
 from .roles import CiteRole
 from .directives import BibliographyDirective
-from .transforms import BibliographyTransform
+from .transforms import BibliographyTransform, PybibtexNodeFormatter
 from .foot_roles import FootCiteRole
 from .foot_directives import FootBibliographyDirective
 
@@ -46,6 +46,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_node(raw_latex, latex=(visit_raw_latex, depart_raw_latex),
                  override=True)
     app.add_post_transform(BibliographyTransform)
+    app.add_post_transform(PybibtexNodeFormatter)
     app.add_domain(BibtexFootDomain)
     app.add_directive("footbibliography", FootBibliographyDirective)
     app.add_role("footcite", FootCiteRole())


### PR DESCRIPTION
This is the post-transform I wrote to fix italics formatting via `\textit` in the bibliography.

I think it should be straightforward to slightly refactor the logic to work with a dictionary like below, this was just not a priority for me.

```python
wrap_fixes = {
    "\textit ": docutils.nodes.emphasis,
    "\textbf ": docutils.nodes.strong,
    "\texttt ": ...
}
```

@mcmtroffaes please let me know how to proceed. If we merge and release this with `sphinxcontrib-bibtex` I can delete the code from my thesis project.

Closes #300