### PR TITLE
Fix docutils blocklist

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Sphinx>=2.1
-docutils>=0.8,!=1.18.*,!=1.19.*
+docutils>=0.8,!=0.18.*,!=0.19.*
 pybtex>=0.24
 pybtex-docutils>=1.0.0
 dataclasses; python_version < '3.7'


### PR DESCRIPTION
docutils 1.x hasn’t been released yet, I guess you mean 0.18.x and 0.19.x