### PR TITLE
bump `docutils`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Sphinx>=2.1
-docutils>=0.8,!=0.18.*,!=0.19.*
+docutils>=0.8,!=0.18.*,!=0.19.*,!=0.20.0
 pybtex>=0.24
 pybtex-docutils>=1.0.0
 dataclasses; python_version < '3.7'


### PR DESCRIPTION
`docutils==0.20.0` is also broken (but 0.20.1 is fine)

Follow-up to #331, #330