### PR TITLE
Fix bibfiles resolve

### DIFF
--- a/src/sphinxcontrib/bibtex/directives.py
+++ b/src/sphinxcontrib/bibtex/directives.py
@@ -11,6 +11,7 @@
 """
 
 import ast  # parse(), used for filter
+from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, NamedTuple, Sequence, cast
 
 import docutils.nodes
@@ -148,7 +149,7 @@ class BibliographyDirective(Directive):
         if self.arguments:
             bibfiles = []
             for bibfile in self.arguments[0].split():
-                normbibfile = normpath_filename(env, bibfile)
+                normbibfile = str(Path(normpath_filename(env, bibfile)).resolve())
                 if normbibfile not in domain.bibdata.bibfiles:
                     logger.warning(
                         "{0} not found or not configured"

--- a/src/sphinxcontrib/bibtex/domain.py
+++ b/src/sphinxcontrib/bibtex/domain.py
@@ -11,6 +11,7 @@ outside the doctree.
 
 import ast
 import re
+from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     AbstractSet,
@@ -300,11 +301,14 @@ class BibtexDomain(Domain):
         # check config
         if env.app.config.bibtex_bibfiles is None:
             raise ExtensionError("You must configure the bibtex_bibfiles setting")
-        # update bib file information in the cache
+        
+        # canonicalize bibfile paths relative to confdir
         bibfiles = [
-            normpath_filename(env, "/" + bibfile)
+            str((Path(env.app.confdir) / bibfile).resolve())
             for bibfile in env.app.config.bibtex_bibfiles
         ]
+
+        # update bib file information in the cache
         self.data["bibdata"] = process_bibdata(
             self.bibdata, bibfiles, env.app.config.bibtex_encoding
         )


### PR DESCRIPTION
bibtex_bibfiles is set in conf.py, so bibfiles should be resolved relative to confdir, not srcdir. confdir is the cwd when this runs, so pathname canonicalization isn't necessary.