### PR TITLE
Document how to remove backrefs with whitespace (closes #364 again)

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -636,8 +636,15 @@ Then, use this code for your ``_static/custom.css`` style sheet:
 .. code-block:: css
 
     .backrefs {
-        display: none;
+        font-size: 0;
     }
+    .backrefs:after {
+        font-size: initial;
+        content: "\00a0";
+    }
+
+Note that links are still rendered but invisible. This means that, for
+example, they will appear if the citation block is copy/pasted.
 
 .. _section-filtering:
 


### PR DESCRIPTION
See #364.

Solution is not entirely satisfactory (see added comment to the doc), I'll let you decide if it's ok.