### PR TITLE
Remove pybtex’ transitive dependency hack

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
 2.6.5 (in development)
 ----------------------
 
+* Require pybtex 0.25 and remove setuptools dependency hack.
+
 2.6.4 (17 June 2025)
 --------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,10 +34,9 @@ classifiers = [
 dependencies = [
     "Sphinx>=3.5",
     "docutils>=0.8,!=0.18.*,!=0.19.*",
-    "pybtex>=0.24",
+    "pybtex>=0.25",
     "pybtex-docutils>=1.0.0",
     "importlib_metadata>=3.6; python_version < '3.10'",
-    "setuptools"  # for pybtex...
 ]
 
 [project.optional-dependencies]

--- a/test/test_bibfiles.py
+++ b/test/test_bibfiles.py
@@ -125,7 +125,7 @@ def test_bibfiles_multiple_keys(app, warning) -> None:
     app.build()
     assert (
         re.search(
-            "bibliography data error in .*: repeated bibliograhpy entry: test",
+            "bibliography data error in .*: repeated bibliography entry: test",
             warning.getvalue(),
         )
         is not None


### PR DESCRIPTION
pybtex 0.25 removed their implicit dependency on setuptools and switched to `importlib.metadata`/`importlib_metadata`: https://bitbucket.org/pybtex-devs/pybtex/branches/compare/0.25.0%0D0.24.0#chg-setup.py