### PR TITLE
Add bibtex-citation CSS class to citation reference wrapper nodes

### DIFF
--- a/src/sphinxcontrib/bibtex/domain.py
+++ b/src/sphinxcontrib/bibtex/domain.py
@@ -452,6 +452,7 @@ class BibtexDomain(Domain):
         ]
         formatted_references = format_references(self.reference_style, typ, references)
         result_node = docutils.nodes.inline(rawsource=target)
+        result_node['classes'].append('bibtex-citation')
         result_node += formatted_references.render(self.backend)
         return result_node
 

--- a/test/common.py
+++ b/test/common.py
@@ -32,7 +32,7 @@ def html_citation_refs_single(
 ):
     title_pattern = rf' title="{title}"' if title is not None else ""
     return re.compile(
-        r'<span id="(?P<id_>{id_})">\['
+        r'<span class="bibtex-citation" id="(?P<id_>{id_})">\['
         r'<a class="reference internal"'
         r' href="(?P<refdoc>[^#]+)?#(?P<refid>{refid})"'
         r"{title_pattern}"

--- a/test/test_debug.py
+++ b/test/test_debug.py
@@ -21,7 +21,7 @@ docutils_citation_xml = """
 
 bibtex_citation_xml = """
     <paragraph>
-        <inline ids="id1">
+        <inline classes="bibtex-citation" ids="id1">
             [
             <reference internal="1" refid="id3" reftitle="The title.">
                 tes
@@ -81,7 +81,7 @@ def test_debug_minimal_example(app, warning) -> None:
     assert [line for line in output.split("\n")][1:] == [
         "    <paragraph>",
         "        See ",
-        '        <inline ids="id1">',
+        '        <inline classes="bibtex-citation" ids="id1">',
         "            Nelson [",
         f'            <reference internal="{1 if docutils_0_22 else True}" refid="id4" '
         'reftitle="Edward Nelson. Radically Elementary Probability Theory. '
@@ -90,7 +90,7 @@ def test_debug_minimal_example(app, warning) -> None:
         "            ]",
         "         for an introduction to non-standard analysis.",
         "        Non-standard analysis is fun ",
-        '        <inline ids="id2">',
+        '        <inline classes="bibtex-citation" ids="id2">',
         "            [",
         f'            <reference internal="{1 if docutils_0_22 else True}" refid="id4" '
         'reftitle="Edward Nelson. Radically Elementary Probability Theory. '


### PR DESCRIPTION
## Summary

Add a `bibtex-citation` CSS class to the citation reference wrapper node created in `resolve_xref()`, enabling Sphinx themes to style citation elements separately from other content.

Fixes #382

## Problem

The `resolve_xref` method creates a bare `docutils.nodes.inline` wrapper with no CSS class:

```python
result_node = docutils.nodes.inline(rawsource=target)
```

This renders as:

```html
<span id="id17">Barillas <em>et al.</em> [<a class="reference internal" href="...">2009</a>]</span>
```

Because the `<span>` has no distinguishing class, themes cannot write CSS selectors to target citation-specific elements. For example, a theme that applies custom styling to `<em>` elements (e.g. colored emphasis) has no way to exclude the `<em>et al.</em>` inside citations.

## Fix

One line added to `domain.py`:

```python
result_node = docutils.nodes.inline(rawsource=target)
result_node['classes'].append('bibtex-citation')  # <-- new
result_node += formatted_references.render(self.backend)
```

This produces:

```html
<span class="bibtex-citation" id="id17">Barillas <em>et al.</em> [<a class="reference internal" href="...">2009</a>]</span>
```

Themes can now write targeted CSS:

```css
.bibtex-citation em {
  font-style: italic;
  color: inherit;
}
```

## Changes

- `src/sphinxcontrib/bibtex/domain.py` — Add `bibtex-citation` class to citation wrapper node
- `test/common.py` — Update `html_citation_refs_single` regex to expect the new class
- `test/test_debug.py` — Update pseudoxml assertions to include the new class
