### PR TITLE
Fix type annotation overrides in domain.py and foot_domain.py

### DIFF
--- a/src/sphinxcontrib/bibtex/domain.py
+++ b/src/sphinxcontrib/bibtex/domain.py
@@ -350,7 +350,9 @@ class BibtexDomain(Domain):
             if bib_key.docname == docname:
                 del self.bibliographies[bib_key]
 
-    def merge_domaindata(self, docnames: List[str], otherdata: Dict[str, Any]) -> None:
+    def merge_domaindata(
+        self, docnames: AbstractSet[str], otherdata: Dict[str, Any]
+    ) -> None:
         for bib_key, bib_value in otherdata["bibliographies"].items():
             if bib_key.docname in docnames:
                 self.bibliographies[bib_key] = bib_value

--- a/src/sphinxcontrib/bibtex/foot_domain.py
+++ b/src/sphinxcontrib/bibtex/foot_domain.py
@@ -70,7 +70,9 @@ class BibtexFootDomain(Domain):
                 header, "foot_bibliography_header"
             )
 
-    def merge_domaindata(self, docnames: List[str], otherdata: Dict[str, Any]) -> None:
+    def merge_domaindata(
+        self, docnames: AbstractSet[str], otherdata: Dict[str, Any]
+    ) -> None:
         """Merge in data regarding *docnames* from domain data
         inventory *otherdata*.
 
@@ -87,7 +89,7 @@ class BibtexFootDomain(Domain):
         target: str,
         node: "pending_xref",
         contnode: docutils.nodes.Element,
-    ) -> List[Tuple[str, docutils.nodes.Element]]:
+    ) -> List[Tuple[str, docutils.nodes.reference]]:
         """Resolve the pending reference *node* with the given *target*,
         where the reference comes from an "any" role.
 


### PR DESCRIPTION
Fixes flake8 F401 and mypy `[override]` errors that are causing CI failures.

### Changes

- **`domain.py`**: Fix `merge_domaindata` parameter type from `List[str]` to `AbstractSet[str]` to match the `sphinx.domains.Domain` supertype
- **`foot_domain.py`**: Fix `merge_domaindata` parameter type from `List[str]` to `AbstractSet[str]` to match the `sphinx.domains.Domain` supertype
- **`foot_domain.py`**: Fix `resolve_any_xref` return type from `List[Tuple[str, Element]]` to `List[Tuple[str, reference]]` to match the supertype

### Errors fixed

```
src/sphinxcontrib/bibtex/domain.py:352: error: Argument 1 of "merge_domaindata" is incompatible with supertype "sphinx.domains.Domain"; supertype defines the argument type as "AbstractSet[str]" [override]
src/sphinxcontrib/bibtex/foot_domain.py:73: error: Argument 1 of "merge_domaindata" is incompatible with supertype "sphinx.domains.Domain"; supertype defines the argument type as "AbstractSet[str]" [override]
src/sphinxcontrib/bibtex/foot_domain.py:82: error: Return type "list[tuple[str, Element]]" of "resolve_any_xref" incompatible with return type "list[tuple[str, reference]]" in supertype "sphinx.domains.Domain" [override]
```
