### PR TITLE
Separate warning category for duplicate local citations.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,15 +1,24 @@
-2.6.6 (in development)
+2.7.0 (in development)
 ----------------------
+
+* **BACKWARD INCOMPATIBLE**
+  A new warning category, ``duplicate_local_citation``, has been introduced.
+  It is triggered when a duplicate citation appears within the same document.
+  The existing ``duplicate_citation`` warning continues to report duplicates but now only across different documents.
+
+  In many cases, users maintain a separate bibliography for each document (often using a ``docname in docnames`` filter).
+  In such setups, duplicate citations across documents are usually acceptable, while duplicates within a single document are not.
+  This distinction allows users to suppress ``duplicate_citation`` warnings while still receiving ``duplicate_local_citation`` warnings.
+
+* When there are duplicate citations,
+  resolve locally first
+  (reported by drbenvincent, see issue #385).
 
 * Increase required pybtex-docutils version to 1.0.2
   (reported by ego-thales).
 
 * Fix test suite for docutils 0.22
   (fixed by mitya57, see pull request #377).
-
-* When there are duplicate citations,
-  resolve locally first
-  (reported by drbenvincent, see issue #385).
 
 * Dropped Python 3.9 support (EOL), added Python 3.14 support.
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -785,7 +785,7 @@ you can:
   need the same citation repeated in the same document
   across multiple bibliographies,
   and/or you want full control about which bibliography
-  each citations links to.
+  each citation links to.
 
 To create a bibliography that includes only citations that were cited
 in the current document, use the following filter:

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -764,11 +764,28 @@ to achieve local bibliographies
 with :rst:role:`cite` and :rst:dir:`bibliography`.
 
 The ``filter`` system for local bibliographies
-can only be used if no citation key is used in more than one
-document. This is not always satisfied. If you need to cite the same
-reference in multiple documents with references to multiple local
-bibliographies, use the ``keyprefix`` system; see
-:ref:`section-key-prefixing`.
+will lead to duplicate citations if any citation key is used in more than one
+document.
+If you need to cite the same
+reference in multiple documents with references to multiple bibliographies,
+you can:
+
+* Suppress the ``bibtex.duplicate_citation`` warning;
+  see :ref:`section-suppressing-warnings`.
+  This is suitable for use cases where you
+  have a single bibliography directive in each document,
+  typically with a ``docname in docnames`` filter.
+  Note that
+  you will still get ``duplicate_local_citation`` warnings
+  for duplicate citations within the same document.
+
+* Alternatively, you can use the ``keyprefix`` system; see
+  :ref:`section-key-prefixing`.
+  This is suitable for advanced use cases where you
+  need the same citation repeated in the same document
+  across multiple bibliographies,
+  and/or you want full control about which bibliography
+  each citations links to.
 
 To create a bibliography that includes only citations that were cited
 in the current document, use the following filter:
@@ -983,6 +1000,8 @@ have:
 
 This adds a rubric title to every bibliography.
 
+.. _section-suppressing-warnings:
+
 Suppressing Warnings
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -1009,6 +1028,7 @@ The complete list of warning subtypes that can be suppressed is::
     bibtex.duplicate_citation
     bibtex.duplicate_id
     bibtex.duplicate_label
+    bibtex.duplicate_local_citation
     bibtex.filter_overrides
     bibtex.filter_syntax_error
     bibtex.key_not_found

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sphinxcontrib-bibtex"
-version = "2.6.6a0"
+version = "2.7.0a0"
 license = "BSD-2-Clause"
 description = "Sphinx extension for BibTeX style citations."
 readme = "README.rst"

--- a/src/sphinxcontrib/bibtex/domain.py
+++ b/src/sphinxcontrib/bibtex/domain.py
@@ -11,6 +11,7 @@ outside the doctree.
 
 import ast
 import re
+from collections import defaultdict
 from collections.abc import Sequence
 from pathlib import Path
 from typing import (
@@ -372,6 +373,7 @@ class BibtexDomain(Domain):
         docnames = list(get_docnames(self.env))
         # we keep track of this to quickly check for duplicates
         used_keys: Set[str] = set()
+        used_keys_per_doc: defaultdict[str, Set[str]] = defaultdict(set)
         used_labels: Dict[str, str] = {}
         for bibliography_key, bibliography in self.bibliographies.items():
             for entry, formatted_entry, tooltip_entry in self.get_formatted_entries(
@@ -381,13 +383,6 @@ class BibtexDomain(Domain):
                 self.env.config.bibtex_tooltips_style,
             ):
                 key = bibliography.keyprefix + formatted_entry.key
-                if bibliography.list_ == "citation" and key in used_keys:
-                    logger.warning(
-                        'duplicate citation for key "%s"' % key,
-                        location=(bibliography_key.docname, bibliography.line),
-                        type="bibtex",
-                        subtype="duplicate_citation",
-                    )
                 self.citations.append(
                     Citation(
                         citation_id=bibliography.citation_nodes[key]["ids"][0],
@@ -399,7 +394,22 @@ class BibtexDomain(Domain):
                     )
                 )
                 if bibliography.list_ == "citation":
+                    if key in used_keys_per_doc[bibliography_key.docname]:
+                        logger.warning(
+                            'duplicate local citation for key "%s"' % key,
+                            location=(bibliography_key.docname, bibliography.line),
+                            type="bibtex",
+                            subtype="duplicate_local_citation",
+                        )
+                    elif key in used_keys:
+                        logger.warning(
+                            'duplicate citation for key "%s"' % key,
+                            location=(bibliography_key.docname, bibliography.line),
+                            type="bibtex",
+                            subtype="duplicate_citation",
+                        )
                     used_keys.add(key)
+                    used_keys_per_doc[bibliography_key.docname].add(key)
                     if formatted_entry.label not in used_labels:
                         used_labels[formatted_entry.label] = formatted_entry.key
                     elif used_labels[formatted_entry.label] != formatted_entry.key:

--- a/test/test_duplicate.py
+++ b/test/test_duplicate.py
@@ -33,7 +33,7 @@ def test_duplicate_citation(app, warning) -> None:
     warning.seek(0)
     warnings = list(warning.readlines())
     assert len(warnings) == 1
-    assert 'duplicate citation for key "Test"' in warnings[0]
+    assert 'duplicate local citation for key "Test"' in warnings[0]
     # assure distinct citation ids
     output = (app.outdir / "index.html").read_text()
     ids = [match.group("id_") for match in html_citations().finditer(output)]


### PR DESCRIPTION
See #385.

@drbenvincent Can you check if this would solve the problem elegantly for you? Basically, users can suppress the duplicate_citation warning, but not the duplicate_local_citation warning, to get the best of both worlds.